### PR TITLE
[Feat/#60] 약속 잡기 친구초대 로직 구현 

### DIFF
--- a/src/main/java/com/example/momogum/apiPayLoad/code/status/ErrorStatus.java
+++ b/src/main/java/com/example/momogum/apiPayLoad/code/status/ErrorStatus.java
@@ -34,7 +34,9 @@ public enum ErrorStatus implements BaseErrorCode {
 
     //search에 사용
     KEYWWORD_BLANK(HttpStatus.BAD_REQUEST,"SEARCH4001","검색어는 필수입니다."),
-    ;
+
+
+    APPOINTMENT_NOT_EXIST(HttpStatus.NOT_FOUND,"APPOINTMENT4001","약속을 찾을 수 없습니다");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/example/momogum/converter/appointmentConverter/AppointmentInviteConverter.java
+++ b/src/main/java/com/example/momogum/converter/appointmentConverter/AppointmentInviteConverter.java
@@ -1,0 +1,18 @@
+package com.example.momogum.converter.appointmentConverter;
+
+import com.example.momogum.domain.UserEntity;
+import com.example.momogum.web.dto.appointment.AppointmentInviteDTO.AppointmentInviteResponseDTO;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AppointmentInviteConverter {
+
+    public AppointmentInviteResponseDTO toResponseDTO(UserEntity user,  boolean isInvited) {
+        return AppointmentInviteResponseDTO.builder()
+                .username(user.getNickname())
+                .name(user.getName())
+                .profileImage(user.getProfileImage().getImageLink())
+                .isInvited(isInvited)
+                .build();
+    }
+}

--- a/src/main/java/com/example/momogum/converter/appointmentConverter/AppointmentInviteConverter.java
+++ b/src/main/java/com/example/momogum/converter/appointmentConverter/AppointmentInviteConverter.java
@@ -1,18 +1,20 @@
 package com.example.momogum.converter.appointmentConverter;
 
 import com.example.momogum.domain.UserEntity;
+import com.example.momogum.domain.common.enums.InvitationStatus;
 import com.example.momogum.web.dto.appointment.AppointmentInviteDTO.AppointmentInviteResponseDTO;
 import org.springframework.stereotype.Component;
+
 
 @Component
 public class AppointmentInviteConverter {
 
-    public AppointmentInviteResponseDTO toResponseDTO(UserEntity user,  boolean isInvited) {
+    public AppointmentInviteResponseDTO toResponseDTO(UserEntity user, InvitationStatus status) {
         return AppointmentInviteResponseDTO.builder()
-                .username(user.getNickname())
+                .nickname(user.getNickname())
                 .name(user.getName())
                 .profileImage(user.getProfileImage().getImageLink())
-                .isInvited(isInvited)
+                .status(status)
                 .build();
     }
 }

--- a/src/main/java/com/example/momogum/converter/appointmentConverter/AppointmentNameConverter.java
+++ b/src/main/java/com/example/momogum/converter/appointmentConverter/AppointmentNameConverter.java
@@ -1,21 +1,23 @@
-package com.example.momogum.converter.appointment;
+package com.example.momogum.converter.appointmentConverter;
 
 import com.example.momogum.converter.Converter;
 import com.example.momogum.domain.appointment.AppointmentName;
+import com.example.momogum.web.dto.appointment.AppointmentNameDTO;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
 
 import static com.example.momogum.web.dto.appointment.AppointMentDTO.*;
+import static com.example.momogum.web.dto.appointment.AppointmentNameDTO.*;
 
 /**
  * 약속 이름 정하기 부분 converter
  */
 @Component
-public class AppointmentNameConverter implements Converter<AppointmentNameDTO, AppointmentName> {
+public class AppointmentNameConverter implements Converter<AppointmentNameResponseDTO, AppointmentName> {
 
     @Override
-    public AppointmentName convert(AppointmentNameDTO request) {
+    public AppointmentName convert(AppointmentNameResponseDTO request) {
 
         return AppointmentName.builder()
                 .name(request.getName())

--- a/src/main/java/com/example/momogum/domain/Following.java
+++ b/src/main/java/com/example/momogum/domain/Following.java
@@ -7,7 +7,7 @@ import lombok.*;
 
 @Entity
 @Table(name = "following", uniqueConstraints = {
-        @UniqueConstraint(columnNames = {"user_id", "following_id"})
+        @UniqueConstraint(columnNames = {"user_entity_id", "following_id"})
 })
 @Getter
 @Setter

--- a/src/main/java/com/example/momogum/domain/Following.java
+++ b/src/main/java/com/example/momogum/domain/Following.java
@@ -7,7 +7,7 @@ import lombok.*;
 
 @Entity
 @Table(name = "following", uniqueConstraints = {
-        @UniqueConstraint(columnNames = {"user_entity_id", "following_id"})
+        @UniqueConstraint(columnNames = {"user_id", "following_id"})
 })
 @Getter
 @Setter
@@ -25,7 +25,7 @@ public class Following extends BaseEntity {
 
     // 팔로우한 사람 (내가 팔로우하는 대상)
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_entity_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false)
     private UserEntity user;
 
     // 내가 팔로우하는 사람

--- a/src/main/java/com/example/momogum/domain/appointment/AppointmentInvitation.java
+++ b/src/main/java/com/example/momogum/domain/appointment/AppointmentInvitation.java
@@ -16,9 +16,14 @@ public class AppointmentInvitation extends BaseEntity {
     // 다수 초대에 있어서 서비스단에서 각 쿼리를 만들어 보내줘야할 듯 합니다
     // 한번에 List<Long> userIds 처리는 어려울 듯 합니다
 
+    //개별 초대 기록의 고유 식별자 (하나의 약속(appointment)에 속하는 공통 식별자가 아님)
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    // 초대된 약속의 ID
+    @Column(name = "appointment_id", nullable = false)
+    private Long appointmentId;
 
     // 초대 상태
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/example/momogum/repository/appoinmentRepo/AppointmentInvitationRepository.java
+++ b/src/main/java/com/example/momogum/repository/appoinmentRepo/AppointmentInvitationRepository.java
@@ -1,7 +1,0 @@
-package com.example.momogum.repository.appoinmentRepo;
-
-import com.example.momogum.domain.appointment.AppointmentInvitation;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface AppointmentInvitationRepository extends JpaRepository<AppointmentInvitation,Long> {
-}

--- a/src/main/java/com/example/momogum/repository/appoinmentRepo/AppointmentInviteRepository.java
+++ b/src/main/java/com/example/momogum/repository/appoinmentRepo/AppointmentInviteRepository.java
@@ -1,16 +1,17 @@
 package com.example.momogum.repository.appoinmentRepo;
 
-import com.example.momogum.domain.Follower;
+import com.example.momogum.domain.UserEntity;
 import com.example.momogum.domain.appointment.AppointmentInvitation;
-import com.example.momogum.web.dto.appointment.AppointmentInviteDTO;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
 public interface AppointmentInviteRepository extends JpaRepository<AppointmentInvitation, Long> {
+
+    boolean existsByAppointmentIdAndUserEntity(Long appointmentId, UserEntity user);
+
+    List<AppointmentInvitation> findByAppointmentId(Long appointmentId);
 
 }

--- a/src/main/java/com/example/momogum/repository/appoinmentRepo/AppointmentInviteRepository.java
+++ b/src/main/java/com/example/momogum/repository/appoinmentRepo/AppointmentInviteRepository.java
@@ -1,0 +1,16 @@
+package com.example.momogum.repository.appoinmentRepo;
+
+import com.example.momogum.domain.Follower;
+import com.example.momogum.domain.appointment.AppointmentInvitation;
+import com.example.momogum.web.dto.appointment.AppointmentInviteDTO;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface AppointmentInviteRepository extends JpaRepository<AppointmentInvitation, Long> {
+
+}

--- a/src/main/java/com/example/momogum/repository/followRepo/FollowingRepository.java
+++ b/src/main/java/com/example/momogum/repository/followRepo/FollowingRepository.java
@@ -4,6 +4,8 @@ import com.example.momogum.domain.Following;
 import com.example.momogum.domain.UserEntity;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface FollowingRepository extends JpaRepository<Following,Long> {
   //long countByFollower(UserEntity follower);
@@ -11,4 +13,10 @@ public interface FollowingRepository extends JpaRepository<Following,Long> {
 
   List<Following> findByUserId (Long userId);
   int countByUserId(Long userId);
+
+  //특정 사용자가 팔로우한 모든 사용자 가져오는 메서드
+  @Query("SELECT f.following FROM Following f WHERE f.user.id = :userId")
+  List<UserEntity> findFollowedUsersByUserId(@Param("userId") Long userId);
+
+
 }

--- a/src/main/java/com/example/momogum/repository/userEntityRepo/UserEntityRepository.java
+++ b/src/main/java/com/example/momogum/repository/userEntityRepo/UserEntityRepository.java
@@ -34,4 +34,7 @@ public interface UserEntityRepository extends JpaRepository<UserEntity,Long> {
             @Param("noSpaceKeyword") String noSpaceKeyword,
             @Param("partialKeyword") String partialKeyword
     );
+
+    Optional<UserEntity> findByNickname(String nickname);
+
 }

--- a/src/main/java/com/example/momogum/service/appointmentService/AppointmentCardService.java
+++ b/src/main/java/com/example/momogum/service/appointmentService/AppointmentCardService.java
@@ -1,4 +1,4 @@
-package com.example.momogum.service.appointment;
+package com.example.momogum.service.appointmentService;
 
 import com.example.momogum.domain.utils.S3UrlProvider;
 import lombok.RequiredArgsConstructor;
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import static com.example.momogum.web.dto.appointment.AppointMentDTO.*;
+import static com.example.momogum.web.dto.appointment.AppointmentCardDTO.*;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/example/momogum/service/appointmentService/AppointmentInviteService.java
+++ b/src/main/java/com/example/momogum/service/appointmentService/AppointmentInviteService.java
@@ -1,0 +1,100 @@
+package com.example.momogum.service.appointmentService;
+
+import com.example.momogum.apiPayLoad.code.status.ErrorStatus;
+import com.example.momogum.apiPayLoad.exception.GeneralException;
+import com.example.momogum.converter.appointmentConverter.AppointmentInviteConverter;
+import com.example.momogum.domain.UserEntity;
+import com.example.momogum.domain.appointment.AppointmentInvitation;
+import com.example.momogum.domain.common.enums.InvitationStatus;
+import com.example.momogum.repository.appoinmentRepo.AppointmentInviteRepository;
+import com.example.momogum.repository.followRepo.FollowingRepository;
+import com.example.momogum.repository.userEntityRepo.UserEntityRepository;
+import com.example.momogum.web.dto.appointment.AppointmentInviteDTO.AppointmentInviteRequestDTO;
+import com.example.momogum.web.dto.appointment.AppointmentInviteDTO.AppointmentInviteResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class AppointmentInviteService {
+
+    private final UserEntityRepository userEntityRepository;
+    private final AppointmentInviteRepository appointmentInviteRepository;
+    private final AppointmentInviteConverter converter;
+    private final FollowingRepository followingRepository;
+
+    /**
+     * GET 약속에 초대 가능한 친구 목록 반환
+     * @return List<AppointmentInviteResponseDTO> 객체
+     */
+    @Transactional(readOnly = true)
+    public List<AppointmentInviteResponseDTO> getFriendsForInvitation(Long appointmentId, Long userId) {
+        // 1. 현재 사용자가 팔로우 중인 사용자 조회
+        List<UserEntity> followedUsers = followingRepository.findFollowedUsersByUserId(userId);
+
+        // 2. 이미 초대된 사용자 조회
+        List<AppointmentInvitation> existingInvitations = appointmentInviteRepository.findByAppointmentId(appointmentId);
+        List<Long> invitedUserIds = existingInvitations.stream()
+                .map(invitation -> invitation.getUserEntity().getId())
+                .toList();
+
+        // 3. 초대 가능한 사용자 필터링
+        List<UserEntity> availableUsers = followedUsers.stream()
+                .filter(user -> !invitedUserIds.contains(user.getId())) // 이미 초대된 사용자 제외
+                .toList();
+
+        // 4. DTO 변환
+        return availableUsers.stream()
+                .map(user -> converter.toResponseDTO(user, InvitationStatus.PENDING))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * POST 약속 잡기에 친구 초대
+     * @return List<AppointmentInviteResponseDTO> 객체
+     */
+    @Transactional
+    public List<AppointmentInviteResponseDTO> inviteFriends(AppointmentInviteRequestDTO request) {
+
+        validateRequest(request);
+
+        List<AppointmentInviteResponseDTO> invitedUsers = new ArrayList<>();
+
+        for(String username : request.getNicknames()) {
+            UserEntity user = userEntityRepository.findByNickname(username)
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+            boolean isInvited = appointmentInviteRepository.existsByAppointmentIdAndUserEntity(request.getAppointmentId(), user);
+            if (isInvited) {
+                continue;
+            }
+
+            AppointmentInvitation invitation = AppointmentInvitation.builder()
+                    .appointmentId(request.getAppointmentId())
+                    .userEntity(user)
+                    .status(InvitationStatus.PENDING)
+                    .build();
+
+            appointmentInviteRepository.save(invitation);
+
+            invitedUsers.add(converter.toResponseDTO(user, InvitationStatus.PENDING));
+        }
+
+        return invitedUsers;
+    }
+
+    private static void validateRequest(AppointmentInviteRequestDTO request) {
+        if (request.getNicknames() == null || request.getNicknames().isEmpty()) {
+            throw new GeneralException(ErrorStatus.MEMBER_NOT_FOUND);
+        }
+
+        if (request.getAppointmentId() == null) {
+            throw new GeneralException(ErrorStatus.APPOINTMENT_NOT_EXIST);
+        }
+    }
+}

--- a/src/main/java/com/example/momogum/service/appointmentService/AppointmentInviteService.java
+++ b/src/main/java/com/example/momogum/service/appointmentService/AppointmentInviteService.java
@@ -2,6 +2,7 @@ package com.example.momogum.service.appointmentService;
 
 import com.example.momogum.apiPayLoad.code.status.ErrorStatus;
 import com.example.momogum.apiPayLoad.exception.GeneralException;
+import com.example.momogum.apiPayLoad.exception.handler.UserEntityHandler;
 import com.example.momogum.converter.appointmentConverter.AppointmentInviteConverter;
 import com.example.momogum.domain.UserEntity;
 import com.example.momogum.domain.appointment.AppointmentInvitation;
@@ -67,7 +68,7 @@ public class AppointmentInviteService {
 
         for(String username : request.getNicknames()) {
             UserEntity user = userEntityRepository.findByNickname(username)
-                    .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+                    .orElseThrow(() -> new UserEntityHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
             boolean isInvited = appointmentInviteRepository.existsByAppointmentIdAndUserEntity(request.getAppointmentId(), user);
             if (isInvited) {

--- a/src/main/java/com/example/momogum/service/appointmentService/AppointmentInviteService.java
+++ b/src/main/java/com/example/momogum/service/appointmentService/AppointmentInviteService.java
@@ -61,7 +61,7 @@ public class AppointmentInviteService {
     @Transactional
     public List<AppointmentInviteResponseDTO> inviteFriends(AppointmentInviteRequestDTO request) {
 
-        validateRequest(request);
+        validateAppointmentInviteRequest(request);
 
         List<AppointmentInviteResponseDTO> invitedUsers = new ArrayList<>();
 
@@ -88,7 +88,7 @@ public class AppointmentInviteService {
         return invitedUsers;
     }
 
-    private static void validateRequest(AppointmentInviteRequestDTO request) {
+    private static void validateAppointmentInviteRequest(AppointmentInviteRequestDTO request) {
         if (request.getNicknames() == null || request.getNicknames().isEmpty()) {
             throw new GeneralException(ErrorStatus.MEMBER_NOT_FOUND);
         }

--- a/src/main/java/com/example/momogum/service/appointmentService/AppointmentNameService.java
+++ b/src/main/java/com/example/momogum/service/appointmentService/AppointmentNameService.java
@@ -1,13 +1,13 @@
-package com.example.momogum.service.appointment;
+package com.example.momogum.service.appointmentService;
 
 
-import com.example.momogum.converter.appointment.AppointmentNameConverter;
+import com.example.momogum.converter.appointmentConverter.AppointmentNameConverter;
 import com.example.momogum.domain.appointment.AppointmentName;
 import com.example.momogum.repository.appoinmentRepo.AppointmentNameRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import static com.example.momogum.web.dto.appointment.AppointMentDTO.*;
+import static com.example.momogum.web.dto.appointment.AppointmentNameDTO.*;
 
 @Service
 @RequiredArgsConstructor
@@ -21,7 +21,7 @@ public class AppointmentNameService {
      * @param request CreateMealPlanNameDTO
      * @return appointmentId
      */
-    public Long creatAppointmentName(AppointmentNameDTO request) {
+    public Long creatAppointmentName(AppointmentNameResponseDTO request) {
 
         AppointmentName appointmentName = converter.convert(request);
 

--- a/src/main/java/com/example/momogum/web/controller/appointment/AppointmentCardsController.java
+++ b/src/main/java/com/example/momogum/web/controller/appointment/AppointmentCardsController.java
@@ -14,7 +14,7 @@ import java.util.List;
 import static com.example.momogum.web.dto.appointment.AppointmentCardDTO.*;
 
 @RestController
-@RequestMapping("/Appointment")
+@RequestMapping("/appointment")
 @RequiredArgsConstructor
 @Tag(name = "약속잡기 카드 선택 및 반환 API")
 public class AppointmentCardsController {

--- a/src/main/java/com/example/momogum/web/controller/appointment/AppointmentCardsController.java
+++ b/src/main/java/com/example/momogum/web/controller/appointment/AppointmentCardsController.java
@@ -1,8 +1,7 @@
 package com.example.momogum.web.controller.appointment;
 
 import com.example.momogum.apiPayLoad.ApiResponse;
-import com.example.momogum.service.appointment.AppointmentCardService;
-import com.example.momogum.web.dto.appointment.AppointMentDTO.AppointmentCardResponseDTO;
+import com.example.momogum.service.appointmentService.AppointmentCardService;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -10,6 +9,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+
+import static com.example.momogum.web.dto.appointment.AppointmentCardDTO.*;
 
 @RestController
 @RequestMapping("/Appointment")

--- a/src/main/java/com/example/momogum/web/controller/appointment/AppointmentCardsController.java
+++ b/src/main/java/com/example/momogum/web/controller/appointment/AppointmentCardsController.java
@@ -3,6 +3,7 @@ package com.example.momogum.web.controller.appointment;
 import com.example.momogum.apiPayLoad.ApiResponse;
 import com.example.momogum.service.appointmentService.AppointmentCardService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,6 +16,7 @@ import static com.example.momogum.web.dto.appointment.AppointmentCardDTO.*;
 @RestController
 @RequestMapping("/Appointment")
 @RequiredArgsConstructor
+@Tag(name = "약속잡기 카드 선택 및 반환 API")
 public class AppointmentCardsController {
 
     private final AppointmentCardService cardService;

--- a/src/main/java/com/example/momogum/web/controller/appointment/AppointmentController.java
+++ b/src/main/java/com/example/momogum/web/controller/appointment/AppointmentController.java
@@ -14,7 +14,7 @@ import static com.example.momogum.web.dto.appointment.AppointMentDTO.*;
 import static com.example.momogum.web.dto.user.UserDTO.*;
 
 @RestController
-@RequestMapping("/Appointment")
+@RequestMapping("/appointment")
 @Tag(name = "약속잡기 관련 API")
 @RequiredArgsConstructor
 public class AppointmentController {

--- a/src/main/java/com/example/momogum/web/controller/appointment/AppointmentInviteController.java
+++ b/src/main/java/com/example/momogum/web/controller/appointment/AppointmentInviteController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/Appointment")
+@RequestMapping("/appointment")
 @RequiredArgsConstructor
 @Tag(name = "약속잡기 친구 초대 API")
 public class AppointmentInviteController {

--- a/src/main/java/com/example/momogum/web/controller/appointment/AppointmentInviteController.java
+++ b/src/main/java/com/example/momogum/web/controller/appointment/AppointmentInviteController.java
@@ -1,0 +1,61 @@
+package com.example.momogum.web.controller.appointment;
+
+import com.example.momogum.service.appointmentService.AppointmentInviteService;
+import com.example.momogum.web.dto.appointment.AppointmentInviteDTO.AppointmentInviteRequestDTO;
+import com.example.momogum.web.dto.appointment.AppointmentInviteDTO.AppointmentInviteResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/Appointment")
+@RequiredArgsConstructor
+@Tag(name = "약속잡기 친구 초대 API")
+public class AppointmentInviteController {
+
+    private final AppointmentInviteService appointmentInviteService;
+
+    /**
+     * GET /Appointment/{appointmentId}/invites
+     * 약속에 초대 가능한 친구 목록 반환
+     */
+    @Operation(
+            summary = "초대 가능한 친구 목록 반환",
+            description = """
+                        지정된 약속 ID에 대해 초대 가능한 친구 목록을 반환합니다.
+                        이미 초대된 친구는 목록에 포함되지 않습니다.
+                    """
+    )
+    @GetMapping("/{appointmentId}/invites")
+    public ResponseEntity<List<AppointmentInviteResponseDTO>> getFriendsForInvitations(
+            @PathVariable Long appointmentId,
+            @RequestParam Long userId
+    ) {
+        List<AppointmentInviteResponseDTO> invitations = appointmentInviteService.getFriendsForInvitation(appointmentId, userId);
+        return ResponseEntity.ok(invitations);
+    }
+
+    /**
+     * POST /Appointment/invites
+     * 약속에 친구 초대
+     */
+    @Operation(
+            summary = "약속에 친구 초대",
+            description = """
+                        요청 본문에는 AppointmentInviteRequestDTO 형태의 데이터를 포함합니다.
+                        데이터는 약속 ID와 초대할 친구들의 username 리스트로 구성됩니다.
+                    """
+    )
+    @PostMapping("/invites")
+    public ResponseEntity<List<AppointmentInviteResponseDTO>> inviteFriends(
+            @RequestBody AppointmentInviteRequestDTO request
+    ) {
+        List<AppointmentInviteResponseDTO> invitedFriends = appointmentInviteService.inviteFriends(request);
+        return ResponseEntity.ok(invitedFriends);
+    }
+
+}

--- a/src/main/java/com/example/momogum/web/controller/appointment/AppointmentNameController.java
+++ b/src/main/java/com/example/momogum/web/controller/appointment/AppointmentNameController.java
@@ -14,7 +14,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/Appointment")
+@RequestMapping("/appointment")
 @Tag(name = "약속잡기 모임 이름 정하기 API")
 @RequiredArgsConstructor
 public class AppointmentNameController {

--- a/src/main/java/com/example/momogum/web/controller/appointment/AppointmentNameController.java
+++ b/src/main/java/com/example/momogum/web/controller/appointment/AppointmentNameController.java
@@ -1,8 +1,9 @@
 package com.example.momogum.web.controller.appointment;
 
 import com.example.momogum.apiPayLoad.ApiResponse;
-import com.example.momogum.service.appointment.AppointmentNameService;
-import com.example.momogum.web.dto.appointment.AppointMentDTO;
+import com.example.momogum.service.appointmentService.AppointmentNameService;
+import com.example.momogum.web.dto.appointment.AppointMentDTO.CreateAppointmentResponseDTO;
+import com.example.momogum.web.dto.appointment.AppointmentNameDTO.AppointmentNameResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -24,11 +25,11 @@ public class AppointmentNameController {
     @Operation(summary = "모임 이름 정하기 API",
             description = "CreateAppointmentNameDTO을 통해 값을 한 번에 입력받습니다.")
     @PostMapping("/name")
-    public ApiResponse<AppointMentDTO.CreateAppointmentResponseDTO> createAppointmentName(@RequestBody @Valid AppointMentDTO.AppointmentNameDTO request) {
+    public ApiResponse<CreateAppointmentResponseDTO> createAppointmentName(@RequestBody @Valid AppointmentNameResponseDTO request) {
         Long appointmentNameId = appointmentNameService.creatAppointmentName(request);
         // 성공 응답 반환
         return ApiResponse.onSuccess(
-                AppointMentDTO.CreateAppointmentResponseDTO.builder()
+                CreateAppointmentResponseDTO.builder()
                         .appointmentId(appointmentNameId)
                         .build()
         );

--- a/src/main/java/com/example/momogum/web/controller/appointment/AppointmentNameController.java
+++ b/src/main/java/com/example/momogum/web/controller/appointment/AppointmentNameController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/Appointment")
-@Tag(name = "약속잡기 관련 API")
+@Tag(name = "약속잡기 모임 이름 정하기 API")
 @RequiredArgsConstructor
 public class AppointmentNameController {
 

--- a/src/main/java/com/example/momogum/web/dto/appointment/AppointMentDTO.java
+++ b/src/main/java/com/example/momogum/web/dto/appointment/AppointMentDTO.java
@@ -31,37 +31,6 @@ public class AppointMentDTO {
         Long appointmentId;
     }
 
-    /**
-     *  약속 식사 모임 이름 정하기 DTO
-     *  엔티티 : CreateAppointmentName
-     */
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class AppointmentNameDTO {
-
-        @Schema(description = "식사 모임 이름")
-        @NotBlank(message = "필수 작성 항목입니다.")
-        String name;
-
-        @Schema(description = "식사 메뉴")
-        @NotBlank(message = "필수 작성 항목입니다.")
-        String menu;
-
-        @Schema(description = "식사 일정")
-        @NotNull(message = "필수 작성 항목입니다.")
-        LocalDateTime date;
-
-        @Schema(description = "식사 모임 위치")
-        @NotBlank(message = "필수 작성 항목입니다.")
-        String location;
-
-        @Schema(description = "특별한 소식")
-        String notes;
-
-    }
-
 
     /**
      * 약속 잡기 DTO
@@ -99,17 +68,5 @@ public class AppointMentDTO {
         @Schema(description = "참여자 목록입니다.")
         List<UserResponseDTO> users;
 
-    }
-
-    /**
-     * S3 -> 카드 조회 DTO
-     */
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class AppointmentCardResponseDTO {
-        private String type;       // 카드 카테고리 (예: 기본, 재미)
-        private String imageUrl;   // S3 이미지 URL
     }
 }

--- a/src/main/java/com/example/momogum/web/dto/appointment/AppointmentCardDTO.java
+++ b/src/main/java/com/example/momogum/web/dto/appointment/AppointmentCardDTO.java
@@ -1,0 +1,21 @@
+package com.example.momogum.web.dto.appointment;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class AppointmentCardDTO {
+
+    /**
+     * S3 -> 카드 조회 DTO
+     */
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AppointmentCardResponseDTO {
+        private String type;       // 카드 카테고리 (예: 기본, 재미)
+        private String imageUrl;   // S3 이미지 URL
+    }
+}

--- a/src/main/java/com/example/momogum/web/dto/appointment/AppointmentInviteDTO.java
+++ b/src/main/java/com/example/momogum/web/dto/appointment/AppointmentInviteDTO.java
@@ -1,0 +1,47 @@
+package com.example.momogum.web.dto.appointment;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class AppointmentInviteDTO {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class AppointmentInviteRequestDTO {
+
+        @Schema(description = "약속 ID")
+        private Long appointmentId;
+
+        @Schema(description = "초대할 친구들의 사용자 이름 리스트")
+        private List<String> usernames;
+
+    }
+
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class AppointmentInviteResponseDTO {
+
+        @Schema(description = "사용자 아이디")
+        private String username;
+
+        @Schema(description = "사용자 이름")
+        private String name;
+
+        @Schema(description = "프로필 이미지")
+        private String profileImage;
+
+        @Schema(description = "초대 여부")
+        private boolean isInvited;
+
+    }
+}

--- a/src/main/java/com/example/momogum/web/dto/appointment/AppointmentInviteDTO.java
+++ b/src/main/java/com/example/momogum/web/dto/appointment/AppointmentInviteDTO.java
@@ -1,5 +1,6 @@
 package com.example.momogum.web.dto.appointment;
 
+import com.example.momogum.domain.common.enums.InvitationStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,7 +21,7 @@ public class AppointmentInviteDTO {
         private Long appointmentId;
 
         @Schema(description = "초대할 친구들의 사용자 이름 리스트")
-        private List<String> usernames;
+        private List<String> nicknames;
 
     }
 
@@ -31,8 +32,8 @@ public class AppointmentInviteDTO {
     @NoArgsConstructor
     public static class AppointmentInviteResponseDTO {
 
-        @Schema(description = "사용자 아이디")
-        private String username;
+        @Schema(description = "사용자 닉네임")
+        private String nickname;
 
         @Schema(description = "사용자 이름")
         private String name;
@@ -41,7 +42,7 @@ public class AppointmentInviteDTO {
         private String profileImage;
 
         @Schema(description = "초대 여부")
-        private boolean isInvited;
+        private InvitationStatus status;
 
     }
 }

--- a/src/main/java/com/example/momogum/web/dto/appointment/AppointmentNameDTO.java
+++ b/src/main/java/com/example/momogum/web/dto/appointment/AppointmentNameDTO.java
@@ -1,0 +1,45 @@
+package com.example.momogum.web.dto.appointment;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+public class AppointmentNameDTO {
+
+    /**
+     *  약속 식사 모임 이름 정하기 DTO
+     *  엔티티 : CreateAppointmentName
+     */
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AppointmentNameResponseDTO {
+
+        @Schema(description = "식사 모임 이름")
+        @NotBlank(message = "필수 작성 항목입니다.")
+        String name;
+
+        @Schema(description = "식사 메뉴")
+        @NotBlank(message = "필수 작성 항목입니다.")
+        String menu;
+
+        @Schema(description = "식사 일정")
+        @NotNull(message = "필수 작성 항목입니다.")
+        LocalDateTime date;
+
+        @Schema(description = "식사 모임 위치")
+        @NotBlank(message = "필수 작성 항목입니다.")
+        String location;
+
+        @Schema(description = "특별한 소식")
+        String notes;
+
+    }
+}

--- a/src/test/java/com/example/momogum/service/appointmentService/AppointmentCardServiceTest.java
+++ b/src/test/java/com/example/momogum/service/appointmentService/AppointmentCardServiceTest.java
@@ -1,7 +1,7 @@
-package com.example.momogum.service.appointment;
+package com.example.momogum.service.appointmentService;
 
 import com.example.momogum.domain.utils.S3UrlProvider;
-import com.example.momogum.web.dto.appointment.AppointMentDTO.AppointmentCardResponseDTO;
+import com.example.momogum.web.dto.appointment.AppointmentCardDTO.AppointmentCardResponseDTO;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;

--- a/src/test/java/com/example/momogum/service/appointmentService/AppointmentInviteServiceTest.java
+++ b/src/test/java/com/example/momogum/service/appointmentService/AppointmentInviteServiceTest.java
@@ -13,6 +13,7 @@ import com.example.momogum.repository.userEntityRepo.UserEntityRepository;
 import com.example.momogum.web.dto.appointment.AppointmentInviteDTO.AppointmentInviteRequestDTO;
 import com.example.momogum.web.dto.appointment.AppointmentInviteDTO.AppointmentInviteResponseDTO;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -105,6 +106,7 @@ class AppointmentInviteServiceTest {
     /**
      * getFriendsForInvitation 테스트
      */
+    @DisplayName("getFriendsForInvitation 테스트")
     @Test
     void getFriendsForInvitation_SuccessTest() {
 
@@ -129,9 +131,7 @@ class AppointmentInviteServiceTest {
         assertEquals("user2", result.get(1).getNickname());
     }
 
-    /**
-     * inviteFriends 테스트 - 둘 다 초대가 되어있지 않은 경우, 둘 다 초대가 되어야 함.
-     */
+    @DisplayName("inviteFriends 테스트 - 둘 다 초대가 되어있지 않은 경우, 둘 다 초대가 되어야 함.")
     @Test
     void inviteFriends_SuccessTest() {
         // given - user1, user2 둘 다 초대가 되어있지 않은 상태
@@ -152,9 +152,7 @@ class AppointmentInviteServiceTest {
         verify(appointmentInviteRepository, times(2)).save(any(AppointmentInvitation.class));
     }
 
-    /**
-     * inviteFriends 테스트 - user1은 초대 X, user2는 초대 O일 경우 -> user2만 초대 되어야 함
-     */
+    @DisplayName("inviteFriends 테스트 - user1은 초대 X, user2는 초대 O일 경우 -> user2만 초대 되어야 함")
     @Test
     void inviteFriends_DuplicateTest() {
         //given - user1은 초대 O, user2은 초대 X
@@ -173,9 +171,7 @@ class AppointmentInviteServiceTest {
         verify(appointmentInviteRepository, times(1)).save(any(AppointmentInvitation.class));
     }
 
-    /**
-     * inviteFriends 테스트 - 초대할 친구를 아무도 지정하지 않았을 경우 -> MEMBER_NOT_FOUND 오류가 발생해야 함.
-     */
+    @DisplayName("inviteFriends 테스트 - 초대할 친구를 아무도 지정하지 않았을 경우 -> MEMBER_NOT_FOUND 오류가 발생해야 함.")
     @Test
     void inviteFriends_InvalidRequest_EmptyUsernamesTest() {
         //given - 초대할 친구를 아무도 지정하지 않았을 경우
@@ -190,9 +186,7 @@ class AppointmentInviteServiceTest {
         assertEquals(ErrorStatus.MEMBER_NOT_FOUND, exception.getCode());
     }
 
-    /**
-     * inviteFriends 테스트 - appointmnetId가 null일 경우 약속 관련 오류 (APPOINTMENT_NOT_EXIST) 발생
-     */
+    @DisplayName("inviteFriends 테스트 - appointmnetId가 null일 경우 약속 관련 오류 (APPOINTMENT_NOT_EXIST) 발생")
     @Test
     void inviteFriends_InvalidRequest_NullAppointmentIdTest() {
         //given - appointmentId == null

--- a/src/test/java/com/example/momogum/service/appointmentService/AppointmentInviteServiceTest.java
+++ b/src/test/java/com/example/momogum/service/appointmentService/AppointmentInviteServiceTest.java
@@ -1,0 +1,209 @@
+package com.example.momogum.service.appointmentService;
+
+import com.example.momogum.apiPayLoad.code.status.ErrorStatus;
+import com.example.momogum.apiPayLoad.exception.GeneralException;
+import com.example.momogum.converter.appointmentConverter.AppointmentInviteConverter;
+import com.example.momogum.domain.UserEntity;
+import com.example.momogum.domain.appointment.AppointmentInvitation;
+import com.example.momogum.domain.common.enums.InvitationStatus;
+import com.example.momogum.domain.common.enums.LoginType;
+import com.example.momogum.repository.appoinmentRepo.AppointmentInviteRepository;
+import com.example.momogum.repository.followRepo.FollowingRepository;
+import com.example.momogum.repository.userEntityRepo.UserEntityRepository;
+import com.example.momogum.web.dto.appointment.AppointmentInviteDTO.AppointmentInviteRequestDTO;
+import com.example.momogum.web.dto.appointment.AppointmentInviteDTO.AppointmentInviteResponseDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class AppointmentInviteServiceTest {
+
+    @InjectMocks
+    private AppointmentInviteService appointmentInviteService;
+
+    @Mock
+    private UserEntityRepository userEntityRepository;
+
+    @Mock
+    private AppointmentInviteRepository appointmentInviteRepository;
+
+    @Mock
+    private AppointmentInviteConverter converter;
+
+    @Mock
+    private FollowingRepository followingRepository;
+
+    private AppointmentInviteRequestDTO request;
+    private UserEntity user1;
+    private UserEntity user2;
+
+
+    @BeforeEach
+    void setUp() {
+
+        // 테스트 요청 객체 생성 (appointmentId와 초대할 사용자 닉네임 목록)
+        request = AppointmentInviteRequestDTO.builder()
+                .appointmentId(1L)
+                .nicknames(List.of("user1", "user2"))
+                .build();
+
+        // 테스트용 UserEntity 생성 (필요한 필드만 설정)
+         user1 = createTestUser(1L, "user1", "유저 닉네임 1");
+         user2 = createTestUser(2L, "user2", "유저 닉네임 2");
+
+        // repository에서 username으로 UserEntity 조회 시 설정
+        when(userEntityRepository.findByNickname("user1")).thenReturn(Optional.of(user1));
+        when(userEntityRepository.findByNickname("user2")).thenReturn(Optional.of(user2));
+
+        // converter의 DTO 변환 결과를 미리 설정 1
+        when(converter.toResponseDTO(user1, InvitationStatus.PENDING))
+                .thenReturn(AppointmentInviteResponseDTO.builder()
+                        .nickname("user1")
+                        .name("유저 닉네임 1")
+                        .profileImage("/path/to/image1")
+                        .status(InvitationStatus.PENDING)
+                        .build());
+
+        // converter의 DTO 변환 결과를 미리 설정 2
+        when(converter.toResponseDTO(user2, InvitationStatus.PENDING))
+                .thenReturn(AppointmentInviteResponseDTO.builder()
+                        .nickname("user2")
+                        .name("유저 닉네임 2")
+                        .profileImage("/path/to/image2")
+                        .status(InvitationStatus.PENDING)
+                        .build());
+    }
+
+    /**
+     * 테스트용 UserEntity 객체를 생성하는 팩토리 메서드.
+     */
+    private UserEntity createTestUser(Long id, String username, String name) {
+        return UserEntity.builder()
+                .id(id)
+                .nickname(username) //username이 nickname의 역할을 수행한다고 가정
+                .name(name)
+                .phoneNumber("010-1234-5678")
+                .about("About " + name)
+                .provider(LoginType.KAKAO)
+                .build();
+    }
+
+    /**
+     * getFriendsForInvitation 테스트
+     */
+    @Test
+    void getFriendsForInvitation_SuccessTest() {
+
+        //given - 특정 appointmentId에 대한 특정 초대 목록 생성
+        Long currentUserId = 100L; //테스트용 ID 생성
+
+        // 1. appointmentId에 대한 초대 내역이 없다고 가정
+        when(appointmentInviteRepository.findByAppointmentId(request.getAppointmentId()))
+                .thenReturn(Collections.emptyList());
+
+        // 2. 현재 사용자가 팔로우 중인 사용자 목록 설정 (user1과 user2)
+        List<UserEntity> followedUsers = List.of(user1, user2);
+        when(followingRepository.findFollowedUsersByUserId(currentUserId))
+                .thenReturn(followedUsers);
+
+        //when - GET 친구 초대 가능 목록 호출 (초대 내역이 없으므로 모든 팔로우 사용자가 대상)
+        List<AppointmentInviteResponseDTO> result = appointmentInviteService.getFriendsForInvitation(request.getAppointmentId(), currentUserId);
+
+        // Then
+        assertEquals(2, result.size());
+        assertEquals("user1", result.get(0).getNickname());
+        assertEquals("user2", result.get(1).getNickname());
+    }
+
+    /**
+     * inviteFriends 테스트 - 둘 다 초대가 되어있지 않은 경우, 둘 다 초대가 되어야 함.
+     */
+    @Test
+    void inviteFriends_SuccessTest() {
+        // given - user1, user2 둘 다 초대가 되어있지 않은 상태
+        when(appointmentInviteRepository.existsByAppointmentIdAndUserEntity(request.getAppointmentId(), user1))
+                .thenReturn(false);
+        when(appointmentInviteRepository.existsByAppointmentIdAndUserEntity(request.getAppointmentId(), user2))
+                .thenReturn(false);
+
+        //when
+        List<AppointmentInviteResponseDTO> result = appointmentInviteService.inviteFriends(request);
+
+        //then
+        assertEquals(2, result.size());
+        assertEquals("user1", result.get(0).getNickname());
+        assertEquals("user2", result.get(1).getNickname());
+
+        //메서드 두 번 호출되었는지 확인
+        verify(appointmentInviteRepository, times(2)).save(any(AppointmentInvitation.class));
+    }
+
+    /**
+     * inviteFriends 테스트 - user1은 초대 X, user2는 초대 O일 경우 -> user2만 초대 되어야 함
+     */
+    @Test
+    void inviteFriends_DuplicateTest() {
+        //given - user1은 초대 O, user2은 초대 X
+        when(appointmentInviteRepository.existsByAppointmentIdAndUserEntity(request.getAppointmentId(), user1))
+                .thenReturn(true);
+        when(appointmentInviteRepository.existsByAppointmentIdAndUserEntity(request.getAppointmentId(), user2))
+                .thenReturn(false);
+
+        //when
+        List<AppointmentInviteResponseDTO> result = appointmentInviteService.inviteFriends(request);
+
+        //then
+        assertEquals(1, result.size());
+        assertEquals("user2", result.get(0).getNickname());
+
+        verify(appointmentInviteRepository, times(1)).save(any(AppointmentInvitation.class));
+    }
+
+    /**
+     * inviteFriends 테스트 - 초대할 친구를 아무도 지정하지 않았을 경우 -> MEMBER_NOT_FOUND 오류가 발생해야 함.
+     */
+    @Test
+    void inviteFriends_InvalidRequest_EmptyUsernamesTest() {
+        //given - 초대할 친구를 아무도 지정하지 않았을 경우
+        AppointmentInviteRequestDTO request = AppointmentInviteRequestDTO.builder()
+                .appointmentId(1L)
+                .nicknames(Collections.emptyList())
+                .build();
+
+        //when & then - 예상 기대값 : GeneralException - MEMBER_NOT_FOUND
+        GeneralException exception = assertThrows(GeneralException.class,
+                () -> appointmentInviteService.inviteFriends(request));
+        assertEquals(ErrorStatus.MEMBER_NOT_FOUND, exception.getCode());
+    }
+
+    /**
+     * inviteFriends 테스트 - appointmnetId가 null일 경우 약속 관련 오류 (APPOINTMENT_NOT_EXIST) 발생
+     */
+    @Test
+    void inviteFriends_InvalidRequest_NullAppointmentIdTest() {
+        //given - appointmentId == null
+        AppointmentInviteRequestDTO invalidRequest = AppointmentInviteRequestDTO.builder()
+                .appointmentId(null)
+                .nicknames(List.of("user1"))
+                .build();
+
+        //when & then - 예상 기대값 : GeneralException - APPOINTMENT_NOT_EXIST
+        GeneralException exception = assertThrows(GeneralException.class,
+                () -> appointmentInviteService.inviteFriends(invalidRequest));
+        assertEquals(ErrorStatus.APPOINTMENT_NOT_EXIST, exception.getCode());
+    }
+}

--- a/src/test/java/com/example/momogum/service/appointmentService/AppointmentNameServiceTest.java
+++ b/src/test/java/com/example/momogum/service/appointmentService/AppointmentNameServiceTest.java
@@ -1,7 +1,8 @@
-package com.example.momogum.service.appointment;
-import com.example.momogum.converter.appointment.AppointmentNameConverter;
+package com.example.momogum.service.appointmentService;
+import com.example.momogum.converter.appointmentConverter.AppointmentNameConverter;
 import com.example.momogum.domain.appointment.AppointmentName;
 import com.example.momogum.repository.appoinmentRepo.AppointmentNameRepository;
+import com.example.momogum.web.dto.appointment.AppointmentNameDTO.AppointmentNameResponseDTO;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -9,7 +10,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import java.time.LocalDateTime;
-import static com.example.momogum.web.dto.appointment.AppointMentDTO.*;
+
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -31,7 +32,7 @@ class AppointmentNameServiceTest {
     void Success_NameTest() {
 
         //given
-        AppointmentNameDTO appointmentNameDTO = AppointmentNameDTO.builder()
+        AppointmentNameResponseDTO appointmentNameDTO = AppointmentNameResponseDTO.builder()
                 .name("더술 출발")
                 .menu("더술 닭 한마리")
                 .date(LocalDateTime.of(2025, 1, 24, 18, 0))
@@ -66,7 +67,7 @@ class AppointmentNameServiceTest {
     void Fail_NameTest() {
 
         //given
-        AppointmentNameDTO appointmentNameDTO = AppointmentNameDTO.builder()
+        AppointmentNameResponseDTO appointmentNameDTO = AppointmentNameResponseDTO.builder()
                 .name("더술 출발")
                 .menu("더술 닭 한마리")
                 .date(LocalDateTime.of(2025, 1, 24, 18, 0))

--- a/src/test/java/com/example/momogum/web/controller/appointment/AppointmentCardsControllerTest.java
+++ b/src/test/java/com/example/momogum/web/controller/appointment/AppointmentCardsControllerTest.java
@@ -1,6 +1,7 @@
 package com.example.momogum.web.controller.appointment;
 
-import com.example.momogum.service.appointment.AppointmentCardService;
+import com.example.momogum.service.appointmentService.AppointmentCardService;
+import com.example.momogum.web.dto.appointment.AppointmentCardDTO.AppointmentCardResponseDTO;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -11,7 +12,6 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
 import java.util.List;
 
-import static com.example.momogum.web.dto.appointment.AppointMentDTO.*;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;

--- a/src/test/java/com/example/momogum/web/controller/appointment/AppointmentNameControllerTest.java
+++ b/src/test/java/com/example/momogum/web/controller/appointment/AppointmentNameControllerTest.java
@@ -1,7 +1,7 @@
 package com.example.momogum.web.controller.appointment;
 
-import com.example.momogum.service.appointment.AppointmentNameService;
-import com.example.momogum.web.dto.appointment.AppointMentDTO;
+import com.example.momogum.service.appointmentService.AppointmentNameService;
+import com.example.momogum.web.dto.appointment.AppointmentNameDTO.AppointmentNameResponseDTO;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -41,7 +41,7 @@ class AppointmentNameControllerTest {
     void Success_NameTest() throws Exception {
 
         //given
-        AppointMentDTO.AppointmentNameDTO appointmentNameDTO = AppointMentDTO.AppointmentNameDTO.builder()
+        AppointmentNameResponseDTO appointmentNameDTO = AppointmentNameResponseDTO.builder()
                 .name("더술 출발")
                 .menu("더술 닭 한마리")
                 .date(LocalDateTime.of(2025, 1, 24, 18, 0))
@@ -77,7 +77,7 @@ class AppointmentNameControllerTest {
     @Test
     void Fail_NameTest() throws Exception {
         //given
-        AppointMentDTO.AppointmentNameDTO appointmentNameDTO = AppointMentDTO.AppointmentNameDTO.builder()
+        AppointmentNameResponseDTO appointmentNameDTO = AppointmentNameResponseDTO.builder()
                 .name("")
                 .menu("더술 닭 한마리")
                 .date(LocalDateTime.of(2025, 1, 24, 18, 0))


### PR DESCRIPTION
## Issue

![image](https://github.com/user-attachments/assets/4e5f2725-10c3-482c-a89e-35ba8dc0126d)


- 이슈 번호 및 링크
#60 

## Summary

- 약속 잡기 친구 초대 로직 구현 검색 기능빼고 완료 하였습니다.


## Describe your code

- 두 가지 로직 구현
- 1) GET API의 경우, 현재 사용자의 팔로우 목록을 조회하고 이미 초대된 사용자의 ID 목록을 기반으로 초대 가능한 친구들을 필터링한 후, DTO로 변환하여 반환
- 2) POST API에서는 요청 데이터(appointmentId와 nicknames)를 검증한 후, 각 닉네임에 해당하는 사용자를 조회하고, 이미 초대된 상태라면 건너뛰며 초대되지 않은 사용자에 대해서만 새로운 초대 엔티티를 생성 및 저장하고 DTO로 변환하여 반환

3) 팔로우 테이블 오류 있어서 살짝 손댔고 UserEntity 관련해서도 조금 추가할 거 추가하고 수정도 하였습니다 확인 부탁드립니다~

4) 서비스 테스트 코드는 다 통과하였고 컨트롤러 테스트 코드는 스프린트를 위해 swagger로 검증할 생각입니다.

5) 친구 초대 스크롤 관련해서는 프론트분과 이야기를 좀 나눈뒤 추가할 건 추가하고 하도록 하겠습니다. 🙂

(approve만 해주시면 감사하겠습니다 ! merge는 제가 하도록 하겠습니다 :))

# Check
- [x] Reviewers 등록을 하였나요?
- [x] Assignees 등록을 하였나요?
- [x] 라벨 등록을 하였나요?
- [x] PR 머지하기 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!
