### PR TITLE
[chore] 기존 팔로우 테이블에 맞게 약속 잡기 친구 초대 부분 수정 및 맞팔로우 테이블 반환 + 테스트 코드 통과

### DIFF
--- a/src/main/java/com/example/momogum/repository/userEntityRepo/UserEntityRepository.java
+++ b/src/main/java/com/example/momogum/repository/userEntityRepo/UserEntityRepository.java
@@ -47,4 +47,6 @@ public interface UserEntityRepository extends JpaRepository<UserEntity, Long> {
 
     Optional<UserEntity> findByNickname(String nickname);
 
+    List<UserEntity> findByNicknameIn(List<String> nicknames);
+
 }

--- a/src/main/java/com/example/momogum/service/appointmentService/AppointmentInviteService.java
+++ b/src/main/java/com/example/momogum/service/appointmentService/AppointmentInviteService.java
@@ -4,10 +4,12 @@ import com.example.momogum.apiPayLoad.code.status.ErrorStatus;
 import com.example.momogum.apiPayLoad.exception.GeneralException;
 import com.example.momogum.apiPayLoad.exception.handler.UserEntityHandler;
 import com.example.momogum.converter.appointmentConverter.AppointmentInviteConverter;
+import com.example.momogum.domain.Follower;
 import com.example.momogum.domain.UserEntity;
 import com.example.momogum.domain.appointment.AppointmentInvitation;
 import com.example.momogum.domain.common.enums.InvitationStatus;
 import com.example.momogum.repository.appoinmentRepo.AppointmentInviteRepository;
+import com.example.momogum.repository.followRepo.FollowerRepository;
 import com.example.momogum.repository.followRepo.FollowingRepository;
 import com.example.momogum.repository.userEntityRepo.UserEntityRepository;
 import com.example.momogum.web.dto.appointment.AppointmentInviteDTO.AppointmentInviteRequestDTO;
@@ -18,6 +20,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
@@ -27,30 +32,49 @@ public class AppointmentInviteService {
     private final UserEntityRepository userEntityRepository;
     private final AppointmentInviteRepository appointmentInviteRepository;
     private final AppointmentInviteConverter converter;
+    private final FollowerRepository followerRepository;
     private final FollowingRepository followingRepository;
 
+
     /**
-     * GET 약속에 초대 가능한 친구 목록 반환
+     * GET 약속에 초대 가능한 친구 목록 반환 (나를 팔로워하는 사람들)
      * @return List<AppointmentInviteResponseDTO> 객체
      */
     @Transactional(readOnly = true)
     public List<AppointmentInviteResponseDTO> getFriendsForInvitation(Long appointmentId, Long userId) {
-        // 1. 현재 사용자가 팔로우 중인 사용자 조회
-        List<UserEntity> followedUsers = followingRepository.findFollowedUsersByUserId(userId);
+        // 1. 나를 팔로우하는 사용자 조회 (팔로워)
+        List<UserEntity> followers = followerRepository.findByUserId(userId)
+                .stream()
+                .map(Follower::getFollower)
+                .toList();
 
-        // 2. 이미 초대된 사용자 조회
-        List<AppointmentInvitation> existingInvitations = appointmentInviteRepository.findByAppointmentId(appointmentId);
-        List<Long> invitedUserIds = existingInvitations.stream()
+        // 2. 내가 팔로우하는 사용자 조회 (팔로잉)
+        List<UserEntity> following = followingRepository.findFollowedUsersByUserId(userId);
+
+        // 3. 맞팔 사용자만 가능하도록 필터링
+        // 3-1) 내가 팔로우 한 사용자의 ID를 조회 후
+        Set<Long> followingIds = following.stream()
+                .map(UserEntity::getId)
+                .collect(Collectors.toSet());
+
+        // 3-2) followers에서 필터링하여 맞팔 되어 있는 사용자(mutualFollowers)만 선택
+        List<UserEntity> mutualFollowers = followers.stream()
+                .filter(user -> followingIds.contains(user.getId()))
+                .toList();
+
+        // 4. 이미 초대된 사용자 조회 (이 부분 유지)
+        List<Long> invitedUserIds = appointmentInviteRepository.findByAppointmentId(appointmentId)
+                .stream()
                 .map(invitation -> invitation.getUserEntity().getId())
                 .toList();
 
-        // 3. 초대 가능한 사용자 필터링
-        List<UserEntity> availableUsers = followedUsers.stream()
-                .filter(user -> !invitedUserIds.contains(user.getId())) // 이미 초대된 사용자 제외
+        // 5. 초대 가능한 사용자 필터링 (이미 초대된 사용자는 제외)
+        List<UserEntity> avaliableUsers = mutualFollowers.stream()
+                .filter(user -> !invitedUserIds.contains(user.getId()))
                 .toList();
 
-        // 4. DTO 변환
-        return availableUsers.stream()
+        // 6. DTO 변환 후 반환
+        return avaliableUsers.stream()
                 .map(user -> converter.toResponseDTO(user, InvitationStatus.PENDING))
                 .collect(Collectors.toList());
     }
@@ -61,30 +85,46 @@ public class AppointmentInviteService {
      */
     @Transactional
     public List<AppointmentInviteResponseDTO> inviteFriends(AppointmentInviteRequestDTO request) {
-
         validateAppointmentInviteRequest(request);
 
+        //1. 체크한 모든 사용자 조회 (Batch 조회)
+        List<UserEntity> users = userEntityRepository.findByNicknameIn(request.getNicknames());
+
+        //2. 조회된 유저를 Map으로 변환하여 빠르게 검색 가능하도록 함. (닉네임 - Key, UserEntity - Value)
+        Map<String, UserEntity> userMap = users.stream()
+                .collect(Collectors.toMap(UserEntity::getNickname, Function.identity()));
+
+        //DB에 저장할 초대 요청 리스트
+        List<AppointmentInvitation> invitationsToSave = new ArrayList<>();
+
+        //클라이언한테 반환할 DTO 리스트
         List<AppointmentInviteResponseDTO> invitedUsers = new ArrayList<>();
 
-        for(String username : request.getNicknames()) {
-            UserEntity user = userEntityRepository.findByNickname(username)
-                    .orElseThrow(() -> new UserEntityHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        for (String username : request.getNicknames()) {
+            UserEntity user = userMap.get(username);
+            if (user == null) {
+                throw new UserEntityHandler(ErrorStatus.MEMBER_NOT_FOUND);
+            }
 
+            //이미 초대된 사용자가 존재하다면 continue
             boolean isInvited = appointmentInviteRepository.existsByAppointmentIdAndUserEntity(request.getAppointmentId(), user);
             if (isInvited) {
                 continue;
             }
 
+            //3. 초대 요청을 위한 객체 생성 후 리스트에 추가 (Bulk insert)
             AppointmentInvitation invitation = AppointmentInvitation.builder()
                     .appointmentId(request.getAppointmentId())
                     .userEntity(user)
                     .status(InvitationStatus.PENDING)
                     .build();
 
-            appointmentInviteRepository.save(invitation);
-
+            invitationsToSave.add(invitation);
             invitedUsers.add(converter.toResponseDTO(user, InvitationStatus.PENDING));
         }
+
+        //4. Batch insert
+        appointmentInviteRepository.saveAll(invitationsToSave);
 
         return invitedUsers;
     }

--- a/src/main/java/com/example/momogum/service/userProfileService/FollowServiceImpl.java
+++ b/src/main/java/com/example/momogum/service/userProfileService/FollowServiceImpl.java
@@ -11,14 +11,16 @@ import com.example.momogum.repository.followRepo.FollowingRepository;
 import com.example.momogum.repository.userEntityRepo.UserEntityRepository;
 import com.example.momogum.web.dto.FollowDTO;
 import com.example.momogum.web.dto.FollowDTO.FollowerResponseDTO;
-import jakarta.transaction.Transactional;
 import java.util.List;
+
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class FollowServiceImpl implements FollowService {
 
   private final FollowingRepository followingRepository;
@@ -69,33 +71,32 @@ public class FollowServiceImpl implements FollowService {
     int followingCount = followingRepository.countByUserId(userId);
 
     return  FollowDTO.FollowStatsDTO.builder()
-        .followerCount(followerCount)
-        .followingCount(followingCount)
-        .build();
+            .followerCount(followerCount)
+            .followingCount(followingCount)
+            .build();
   }
 
   /**
    *  맞팔로우 확인 메서드
    */
-
-  private Boolean isMutualFollow(UserEntity currentUser, UserEntity targetUser) {
-    return followerRepository.existsByUserAndFollower(targetUser, currentUser) ? true : null;
+  public Boolean isMutualFollow(UserEntity currentUser, UserEntity targetUser) {
+    return followerRepository.existsByUserAndFollower(targetUser, currentUser)
+            && followerRepository.existsByUserAndFollower(currentUser, targetUser);
   }
 
   /**
    * 팔로잉 목록 조회 (내가 팔로우한 사람들)
    */
   @Override
-  @Transactional
   public List<FollowDTO.FollowingResponseDTO> getFollowings(Long userId) {
     UserEntity user = findUserById(userId);
 
     return followingRepository.findByUserId(userId).stream()
-        .map(following -> FollowConverter.toFollowingResponseDTO(
-            following.getFollowing(),
-            isMutualFollow(user, following.getFollowing())
-        ))
-        .collect(Collectors.toList());
+            .map(following -> FollowConverter.toFollowingResponseDTO(
+                    following.getFollowing(),
+                    isMutualFollow(user, following.getFollowing())
+            ))
+            .collect(Collectors.toList());
   }
 
   /**
@@ -107,11 +108,11 @@ public class FollowServiceImpl implements FollowService {
     UserEntity user = findUserById(userId);
 
     return followerRepository.findByUserId(userId).stream()
-        .map(follower -> FollowConverter.toFollowerResponseDTO(
-            follower.getFollower(),
-            isMutualFollow(user, follower.getFollower())
-        ))
-        .collect(Collectors.toList());
+            .map(follower -> FollowConverter.toFollowerResponseDTO(
+                    follower.getFollower(),
+                    isMutualFollow(user, follower.getFollower())
+            ))
+            .collect(Collectors.toList());
   }
 
   /**
@@ -119,7 +120,7 @@ public class FollowServiceImpl implements FollowService {
    */
   private UserEntity findUserById(Long userId) {
     return userEntityRepository.findById(userId).orElseThrow(
-        () -> new UserEntityHandler(ErrorStatus.MEMBER_NOT_FOUND)
+            () -> new UserEntityHandler(ErrorStatus.MEMBER_NOT_FOUND)
     );
   }
 
@@ -131,12 +132,12 @@ public class FollowServiceImpl implements FollowService {
     UserEntity user = findUserById(userId);
 
     return followingRepository.searchFollowingsByQuery(userId, query)
-        .stream()
-        .map(following -> FollowConverter.toFollowingResponseDTO(
-            following.getFollowing(),
-            isMutualFollow(user, following.getFollowing())
-        ))
-        .collect(Collectors.toList());
+            .stream()
+            .map(following -> FollowConverter.toFollowingResponseDTO(
+                    following.getFollowing(),
+                    isMutualFollow(user, following.getFollowing())
+            ))
+            .collect(Collectors.toList());
   }
 
   /**
@@ -147,12 +148,12 @@ public class FollowServiceImpl implements FollowService {
     UserEntity user = findUserById(userId);
 
     return followerRepository.searchFollowersByQuery(userId, query)
-        .stream()
-        .map(follower -> FollowConverter.toFollowerResponseDTO(
-            follower.getFollower(),
-            isMutualFollow(user, follower.getFollower())
-        ))
-        .collect(Collectors.toList());
+            .stream()
+            .map(follower -> FollowConverter.toFollowerResponseDTO(
+                    follower.getFollower(),
+                    isMutualFollow(user, follower.getFollower())
+            ))
+            .collect(Collectors.toList());
   }
 
 }

--- a/src/test/java/com/example/momogum/service/appointmentService/AppointmentInviteServiceTest.java
+++ b/src/test/java/com/example/momogum/service/appointmentService/AppointmentInviteServiceTest.java
@@ -3,12 +3,14 @@ package com.example.momogum.service.appointmentService;
 import com.example.momogum.apiPayLoad.code.status.ErrorStatus;
 import com.example.momogum.apiPayLoad.exception.GeneralException;
 import com.example.momogum.converter.appointmentConverter.AppointmentInviteConverter;
+import com.example.momogum.domain.Follower;
 import com.example.momogum.domain.UserEntity;
 import com.example.momogum.domain.appointment.AppointmentInvitation;
 import com.example.momogum.domain.common.enums.InvitationStatus;
 import com.example.momogum.domain.common.enums.LoginType;
 import com.example.momogum.domain.utils.JwtUtil;
 import com.example.momogum.repository.appoinmentRepo.AppointmentInviteRepository;
+import com.example.momogum.repository.followRepo.FollowerRepository;
 import com.example.momogum.repository.followRepo.FollowingRepository;
 import com.example.momogum.repository.userEntityRepo.UserEntityRepository;
 import com.example.momogum.web.dto.appointment.AppointmentInviteDTO.AppointmentInviteRequestDTO;
@@ -54,10 +56,12 @@ class AppointmentInviteServiceTest {
     @Mock
     private FollowingRepository followingRepository;
 
+    @Mock
+    private FollowerRepository followerRepository;
+
     private AppointmentInviteRequestDTO request;
     private UserEntity user1;
     private UserEntity user2;
-
 
     @BeforeEach
     void setUp() {
@@ -69,30 +73,19 @@ class AppointmentInviteServiceTest {
                 .build();
 
         // 테스트용 UserEntity 생성 (필요한 필드만 설정)
-         user1 = createTestUser(1L, "user1", "유저 닉네임 1");
-         user2 = createTestUser(2L, "user2", "유저 닉네임 2");
+        user1 = createTestUser(1L, "user1", "유저 닉네임 1");
+        user2 = createTestUser(2L, "user2", "유저 닉네임 2");
 
         // repository에서 username으로 UserEntity 조회 시 설정
-        when(userEntityRepository.findByNickname("user1")).thenReturn(Optional.of(user1));
-        when(userEntityRepository.findByNickname("user2")).thenReturn(Optional.of(user2));
+        when(userEntityRepository.findByNicknameIn(List.of("user1", "user2")))
+                .thenReturn(List.of(user1, user2));
 
         // converter의 DTO 변환 결과를 미리 설정 1
         when(converter.toResponseDTO(user1, InvitationStatus.PENDING))
-                .thenReturn(AppointmentInviteResponseDTO.builder()
-                        .nickname("user1")
-                        .name("유저 닉네임 1")
-                        .profileImage("/path/to/image1")
-                        .status(InvitationStatus.PENDING)
-                        .build());
+                .thenReturn(new AppointmentInviteResponseDTO("user1", "유저 닉네임 1", "/path/to/image1", InvitationStatus.PENDING));
 
-        // converter의 DTO 변환 결과를 미리 설정 2
         when(converter.toResponseDTO(user2, InvitationStatus.PENDING))
-                .thenReturn(AppointmentInviteResponseDTO.builder()
-                        .nickname("user2")
-                        .name("유저 닉네임 2")
-                        .profileImage("/path/to/image2")
-                        .status(InvitationStatus.PENDING)
-                        .build());
+                .thenReturn(new AppointmentInviteResponseDTO("user2", "유저 닉네임 2", "/path/to/image2", InvitationStatus.PENDING));
     }
 
     /**
@@ -110,34 +103,41 @@ class AppointmentInviteServiceTest {
     }
 
     /**
-     * getFriendsForInvitation 테스트
+     * 맞팔된 사용자만 초대 가능 테스트
      */
-    @DisplayName("getFriendsForInvitation 테스트")
+    @DisplayName("맞팔된 사용자만 초대 가능 - getFriendsForInvitation 테스트")
     @Test
     void getFriendsForInvitation_SuccessTest() {
 
-        //given - 특정 appointmentId에 대한 특정 초대 목록 생성
-        Long currentUserId = 100L; //테스트용 ID 생성
+        //Given - 특정 appointmentId에 대한 특정 초대 목록 생성
+        Long currentUserId = 100L; //테스트용 유저 ID 생성
 
-        // 1. appointmentId에 대한 초대 내역이 없다고 가정
+        // 현재 사용자가 팔로잉 하고 있는 목록 설정 (사용자 -> 팔로우 -> user1, user2)
+        List<UserEntity> followingUsers = List.of(user1, user2);
+        when(followingRepository.findFollowedUsersByUserId(currentUserId))
+                .thenReturn(followingUsers);
+
+        // 현재 사용자를 팔로우하는 목록 설정 (user1만 맞팔)
+        when(followerRepository.findByUserId(currentUserId))
+                .thenReturn(List.of(new Follower(1L, createTestUser(currentUserId, "currentUser", "현재 사용자"), user1)));
+
+        // 이미 초대된 사용자 목록 (초대된 사람 없다고 가정)
         when(appointmentInviteRepository.findByAppointmentId(request.getAppointmentId()))
                 .thenReturn(Collections.emptyList());
 
-        // 2. 현재 사용자가 팔로우 중인 사용자 목록 설정 (user1과 user2)
-        List<UserEntity> followedUsers = List.of(user1, user2);
-        when(followingRepository.findFollowedUsersByUserId(currentUserId))
-                .thenReturn(followedUsers);
-
-        //when - GET 친구 초대 가능 목록 호출 (초대 내역이 없으므로 모든 팔로우 사용자가 대상)
+        //When
         List<AppointmentInviteResponseDTO> result = appointmentInviteService.getFriendsForInvitation(request.getAppointmentId(), currentUserId);
 
-        // Then
-        assertEquals(2, result.size());
+        //Then - user1만 조회되어야 함
+        assertEquals(1, result.size());
         assertEquals("user1", result.get(0).getNickname());
-        assertEquals("user2", result.get(1).getNickname());
+
     }
 
-    @DisplayName("inviteFriends 테스트 - 둘 다 초대가 되어있지 않은 경우, 둘 다 초대가 되어야 함.")
+    /**
+     * 초대 성공 리스트 - Batch Insert
+     */
+    @DisplayName("inviteFriends 테스트 - Batch Insert로 초대 저장")
     @Test
     void inviteFriends_SuccessTest() {
         // given - user1, user2 둘 다 초대가 되어있지 않은 상태
@@ -154,27 +154,27 @@ class AppointmentInviteServiceTest {
         assertEquals("user1", result.get(0).getNickname());
         assertEquals("user2", result.get(1).getNickname());
 
-        //메서드 두 번 호출되었는지 확인
-        verify(appointmentInviteRepository, times(2)).save(any(AppointmentInvitation.class));
+        //Batch Insert -> saveAll()이 1번 호출되어야 함
+        verify(appointmentInviteRepository, times(1)).saveAll(anyList());
     }
 
-    @DisplayName("inviteFriends 테스트 - user1은 초대 X, user2는 초대 O일 경우 -> user2만 초대 되어야 함")
+    @DisplayName("inviteFriends 테스트 - 이미 초대된 사용자는 제외")
     @Test
     void inviteFriends_DuplicateTest() {
-        //given - user1은 초대 O, user2은 초대 X
+        //given - user1은 초대 X, user2은 초대 O
         when(appointmentInviteRepository.existsByAppointmentIdAndUserEntity(request.getAppointmentId(), user1))
-                .thenReturn(true);
-        when(appointmentInviteRepository.existsByAppointmentIdAndUserEntity(request.getAppointmentId(), user2))
                 .thenReturn(false);
+        when(appointmentInviteRepository.existsByAppointmentIdAndUserEntity(request.getAppointmentId(), user2))
+                .thenReturn(true);
 
         //when
         List<AppointmentInviteResponseDTO> result = appointmentInviteService.inviteFriends(request);
 
         //then
         assertEquals(1, result.size());
-        assertEquals("user2", result.get(0).getNickname());
+        assertEquals("user1", result.get(0).getNickname());
 
-        verify(appointmentInviteRepository, times(1)).save(any(AppointmentInvitation.class));
+        verify(appointmentInviteRepository, times(1)).saveAll(anyList());
     }
 
     @DisplayName("inviteFriends 테스트 - 초대할 친구를 아무도 지정하지 않았을 경우 -> MEMBER_NOT_FOUND 오류가 발생해야 함.")


### PR DESCRIPTION

## Issue
- #69 

<img width="579" alt="스크린샷 2025-02-10 오후 3 09 30" src="https://github.com/user-attachments/assets/88270de6-fe35-4698-b593-a459d4dc8009" />


## Summary

- 팔로우 테이블 구현이 완료되어 그에 맞춰 검색바 제외 맞팔로우 테이블 초대 구현 및 친구 초대 (중복 필터링) 구현하였습니다~
- 스크롤이랑 검색바는 생각을 좀 해봐야할 것 같습니다!

## Describe your code

- **UserEntityRepository** - findByNicknameIn (Batch Insert) 쿼리 추가
- **FollowServiceImpl** - transactional 의존성 잘못되어 수정하였고, 조회 쿼리 readOnly로 최적화 하였습니다.
- **기존 서비스 쿼리**를 Batch Insert, Map, Set 사용하여 O(1)로 최대한 맞추도록 노력했고,
- **Test 코드** 짠다음 다 잘 돌아가는거 확인하였습니다 ~
- 궁금하신 부분 편하게 여쭤봐주시면 감사하겠습니다 다들 커밋 부탁드립니다!

# Check
- [ ] Reviewers 등록을 하였나요?
- [ ] Assignees 등록을 하였나요?
- [ ] 라벨 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!
