### PR TITLE
[fix] 배포 환경 프로필 이미지 엔티티  created_at, updated_at  null 에러 수정

### DIFF
--- a/src/main/java/com/example/momogum/domain/ProfileImage.java
+++ b/src/main/java/com/example/momogum/domain/ProfileImage.java
@@ -1,13 +1,6 @@
 package com.example.momogum.domain;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -52,4 +45,24 @@ public class ProfileImage {
   @Column
   private String imageName;
 
+
+  @Column(nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @Column(nullable = false)
+  private LocalDateTime updatedAt;
+
+
+  // 저장 전 자동으로 현재 시간 설정
+  @PrePersist
+  public void prePersist() {
+    this.createdAt = LocalDateTime.now();
+    this.updatedAt = LocalDateTime.now();
+  }
+
+  // 업데이트 전 자동으로 변경 시간 설정
+  @PreUpdate
+  public void preUpdate() {
+    this.updatedAt = LocalDateTime.now();
+  }
 }

--- a/src/main/java/com/example/momogum/service/TokenService.java
+++ b/src/main/java/com/example/momogum/service/TokenService.java
@@ -18,6 +18,7 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
+import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -72,6 +73,8 @@ public class TokenService {
                     .fileName("example-file-name")  // 실제 파일 이름
                     .imageName("example-original-name")  // 원본 파일 이름
                     .build();
+
+
 
             // 양방향 연관 관계 설정
             profileImage.setUser(newUser);


### PR DESCRIPTION
## Issue

- #34 


## Summary

- 배포 환경에서 카카오 신규 유저 생성 시 ProfileImage 엔티티의 created_at, updated_at  필드가  null 값일 때 에러 발생
<img width="1366" alt="image" src="https://github.com/user-attachments/assets/5edb5e73-7cce-4c29-9bf2-e4d70bb8dc1c" />


## Describe your code

- ProfileImage에서 명시적으로 createdAt, updatedAt  값 저장하도록 수정

# Check
- [x] Reviewers 등록을 하였나요?
- [x] Assignees 등록을 하였나요?
- [x] 라벨 등록을 하였나요?
- [x] PR 머지하기 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!
